### PR TITLE
fix metal duplication glitch

### DIFF
--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/alnico_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/alnico_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/double_ingot/alnico"
+    "item": "tfc_metallum:metal/double_sheet/alnico"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/alnico"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/alnico_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/alnico_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/ingot/alnico"
+    "item": "tfc_metallum:metal/sheet/alnico"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/alnico"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/aluminum_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/aluminum_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/double_ingot/aluminum"
+    "item": "tfc_metallum:metal/double_sheet/aluminum"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/aluminum"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/aluminum_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/aluminum_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/ingot/aluminum"
+    "item": "tfc_metallum:metal/sheet/aluminum"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/aluminum"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/andesite_alloy_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/andesite_alloy_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/double_ingot/andesite_alloy"
+    "item": "tfc_metallum:metal/double_sheet/andesite_alloy"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/andesite_alloy"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/andesite_alloy_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/andesite_alloy_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/ingot/andesite_alloy"
+    "item": "tfc_metallum:metal/sheet/andesite_alloy"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/andesite_alloy"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/antimony_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/antimony_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/double_ingot/antimony"
+    "item": "tfc_metallum:metal/double_sheet/antimony"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/antimony"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/antimony_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/antimony_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/ingot/antimony"
+    "item": "tfc_metallum:metal/sheet/antimony"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/antimony"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/beryllium_copper_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/beryllium_copper_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/double_ingot/beryllium_copper"
+    "item": "tfc_metallum:metal/double_sheet/beryllium_copper"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/beryllium_copper"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/beryllium_copper_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/beryllium_copper_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/ingot/beryllium_copper"
+    "item": "tfc_metallum:metal/sheet/beryllium_copper"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/beryllium_copper"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/beryllium_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/beryllium_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/double_ingot/beryllium"
+    "item": "tfc_metallum:metal/double_sheet/beryllium"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/beryllium"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/beryllium_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/beryllium_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/ingot/beryllium"
+    "item": "tfc_metallum:metal/sheet/beryllium"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/beryllium"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/bismuth_bronze_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/bismuth_bronze_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc:metal/double_ingot/bismuth_bronze"
+    "item": "tfc:metal/double_sheet/bismuth_bronze"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/bismuth_bronze"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/bismuth_bronze_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/bismuth_bronze_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc:metal/ingot/bismuth_bronze"
+    "item": "tfc:metal/sheet/bismuth_bronze"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/bismuth_bronze"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/bismuth_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/bismuth_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc:metal/double_ingot/bismuth"
+    "item": "tfc:metal/double_sheet/bismuth"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/bismuth"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/bismuth_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/bismuth_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc:metal/ingot/bismuth"
+    "item": "tfc:metal/sheet/bismuth"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/bismuth"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/black_bronze_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/black_bronze_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc:metal/double_ingot/black_bronze"
+    "item": "tfc:metal/double_sheet/black_bronze"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/black_bronze"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/black_bronze_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/black_bronze_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc:metal/ingot/black_bronze"
+    "item": "tfc:metal/sheet/black_bronze"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/black_bronze"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/black_steel_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/black_steel_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc:metal/double_ingot/black_steel"
+    "item": "tfc:metal/double_sheet/black_steel"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/black_steel"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/black_steel_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/black_steel_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc:metal/ingot/black_steel"
+    "item": "tfc:metal/sheet/black_steel"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/black_steel"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/blue_steel_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/blue_steel_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc:metal/double_ingot/blue_steel"
+    "item": "tfc:metal/double_sheet/blue_steel"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/blue_steel"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/blue_steel_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/blue_steel_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc:metal/ingot/blue_steel"
+    "item": "tfc:metal/sheet/blue_steel"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/blue_steel"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/blutonium_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/blutonium_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/double_ingot/blutonium"
+    "item": "tfc_metallum:metal/double_sheet/blutonium"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/blutonium"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/blutonium_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/blutonium_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/ingot/blutonium"
+    "item": "tfc_metallum:metal/sheet/blutonium"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/blutonium"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/boron_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/boron_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/double_ingot/boron"
+    "item": "tfc_metallum:metal/double_sheet/boron"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/boron"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/boron_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/boron_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/ingot/boron"
+    "item": "tfc_metallum:metal/sheet/boron"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/boron"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/brass_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/brass_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc:metal/double_ingot/brass"
+    "item": "tfc:metal/double_sheet/brass"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/brass"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/brass_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/brass_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc:metal/ingot/brass"
+    "item": "tfc:metal/sheet/brass"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/brass"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/bronze_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/bronze_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc:metal/double_ingot/bronze"
+    "item": "tfc:metal/double_sheet/bronze"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/bronze"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/bronze_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/bronze_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc:metal/ingot/bronze"
+    "item": "tfc:metal/sheet/bronze"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/bronze"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/cast_iron_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/cast_iron_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc:metal/double_ingot/cast_iron"
+    "item": "tfc:metal/double_sheet/cast_iron"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/cast_iron"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/cast_iron_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/cast_iron_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc:metal/ingot/cast_iron"
+    "item": "tfc:metal/sheet/cast_iron"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/cast_iron"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/chromium_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/chromium_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "firmalife:metal/double_ingot/chromium"
+    "item": "firmalife:metal/double_sheet/chromium"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/chromium"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/chromium_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/chromium_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "firmalife:metal/ingot/chromium"
+    "item": "firmalife:metal/sheet/chromium"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/chromium"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/cobalt_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/cobalt_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/double_ingot/cobalt"
+    "item": "tfc_metallum:metal/double_sheet/cobalt"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/cobalt"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/cobalt_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/cobalt_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/ingot/cobalt"
+    "item": "tfc_metallum:metal/sheet/cobalt"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/cobalt"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/compressed_iron_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/compressed_iron_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/double_ingot/compressed_iron"
+    "item": "tfc_metallum:metal/double_sheet/compressed_iron"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/compressed_iron"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/compressed_iron_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/compressed_iron_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/ingot/compressed_iron"
+    "item": "tfc_metallum:metal/sheet/compressed_iron"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/compressed_iron"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/constantan_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/constantan_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/double_ingot/constantan"
+    "item": "tfc_metallum:metal/double_sheet/constantan"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/constantan"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/constantan_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/constantan_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/ingot/constantan"
+    "item": "tfc_metallum:metal/sheet/constantan"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/constantan"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/copper_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/copper_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc:metal/double_ingot/copper"
+    "item": "tfc:metal/double_sheet/copper"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/copper"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/copper_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/copper_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc:metal/ingot/copper"
+    "item": "tfc:metal/sheet/copper"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/copper"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/electrum_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/electrum_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/double_ingot/electrum"
+    "item": "tfc_metallum:metal/double_sheet/electrum"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/electrum"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/electrum_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/electrum_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/ingot/electrum"
+    "item": "tfc_metallum:metal/sheet/electrum"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/electrum"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/enderium_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/enderium_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/double_ingot/enderium"
+    "item": "tfc_metallum:metal/double_sheet/enderium"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/enderium"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/enderium_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/enderium_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/ingot/enderium"
+    "item": "tfc_metallum:metal/sheet/enderium"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/enderium"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/ferroboron_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/ferroboron_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/double_ingot/ferroboron"
+    "item": "tfc_metallum:metal/double_sheet/ferroboron"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/ferroboron"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/ferroboron_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/ferroboron_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/ingot/ferroboron"
+    "item": "tfc_metallum:metal/sheet/ferroboron"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/ferroboron"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/florentine_bronze_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/florentine_bronze_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/double_ingot/florentine_bronze"
+    "item": "tfc_metallum:metal/double_sheet/florentine_bronze"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/florentine_bronze"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/florentine_bronze_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/florentine_bronze_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/ingot/florentine_bronze"
+    "item": "tfc_metallum:metal/sheet/florentine_bronze"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/florentine_bronze"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/gold_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/gold_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc:metal/double_ingot/gold"
+    "item": "tfc:metal/double_sheet/gold"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/gold"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/gold_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/gold_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc:metal/ingot/gold"
+    "item": "tfc:metal/sheet/gold"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/gold"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/graphite_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/graphite_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/double_ingot/graphite"
+    "item": "tfc_metallum:metal/double_sheet/graphite"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/graphite"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/graphite_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/graphite_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/ingot/graphite"
+    "item": "tfc_metallum:metal/sheet/graphite"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/graphite"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/invar_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/invar_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/double_ingot/invar"
+    "item": "tfc_metallum:metal/double_sheet/invar"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/invar"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/invar_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/invar_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/ingot/invar"
+    "item": "tfc_metallum:metal/sheet/invar"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/invar"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/iridium_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/iridium_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/double_ingot/iridium"
+    "item": "tfc_metallum:metal/double_sheet/iridium"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/iridium"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/iridium_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/iridium_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/ingot/iridium"
+    "item": "tfc_metallum:metal/sheet/iridium"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/iridium"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/lead_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/lead_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/double_ingot/lead"
+    "item": "tfc_metallum:metal/double_sheet/lead"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/lead"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/lead_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/lead_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/ingot/lead"
+    "item": "tfc_metallum:metal/sheet/lead"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/lead"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/lumium_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/lumium_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/double_ingot/lumium"
+    "item": "tfc_metallum:metal/double_sheet/lumium"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/lumium"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/lumium_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/lumium_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/ingot/lumium"
+    "item": "tfc_metallum:metal/sheet/lumium"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/lumium"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/mithril_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/mithril_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/double_ingot/mithril"
+    "item": "tfc_metallum:metal/double_sheet/mithril"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/mithril"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/mithril_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/mithril_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/ingot/mithril"
+    "item": "tfc_metallum:metal/sheet/mithril"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/mithril"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/nickel_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/nickel_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc:metal/double_ingot/nickel"
+    "item": "tfc:metal/double_sheet/nickel"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/nickel"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/nickel_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/nickel_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc:metal/ingot/nickel"
+    "item": "tfc:metal/sheet/nickel"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/nickel"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/nickel_silver_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/nickel_silver_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/double_ingot/nickel_silver"
+    "item": "tfc_metallum:metal/double_sheet/nickel_silver"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/nickel_silver"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/nickel_silver_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/nickel_silver_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/ingot/nickel_silver"
+    "item": "tfc_metallum:metal/sheet/nickel_silver"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/nickel_silver"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/osmiridium_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/osmiridium_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/double_ingot/osmiridium"
+    "item": "tfc_metallum:metal/double_sheet/osmiridium"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/osmiridium"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/osmiridium_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/osmiridium_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/ingot/osmiridium"
+    "item": "tfc_metallum:metal/sheet/osmiridium"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/osmiridium"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/osmium_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/osmium_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/double_ingot/osmium"
+    "item": "tfc_metallum:metal/double_sheet/osmium"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/osmium"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/osmium_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/osmium_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/ingot/osmium"
+    "item": "tfc_metallum:metal/sheet/osmium"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/osmium"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/pewter_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/pewter_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/double_ingot/pewter"
+    "item": "tfc_metallum:metal/double_sheet/pewter"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/pewter"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/pewter_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/pewter_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/ingot/pewter"
+    "item": "tfc_metallum:metal/sheet/pewter"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/pewter"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/pink_slime_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/pink_slime_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/double_ingot/pink_slime"
+    "item": "tfc_metallum:metal/double_sheet/pink_slime"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/pink_slime"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/pink_slime_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/pink_slime_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/ingot/pink_slime"
+    "item": "tfc_metallum:metal/sheet/pink_slime"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/pink_slime"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/platinum_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/platinum_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/double_ingot/platinum"
+    "item": "tfc_metallum:metal/double_sheet/platinum"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/platinum"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/platinum_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/platinum_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/ingot/platinum"
+    "item": "tfc_metallum:metal/sheet/platinum"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/platinum"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/red_steel_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/red_steel_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc:metal/double_ingot/red_steel"
+    "item": "tfc:metal/double_sheet/red_steel"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/red_steel"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/red_steel_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/red_steel_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc:metal/ingot/red_steel"
+    "item": "tfc:metal/sheet/red_steel"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/red_steel"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/refined_glowstone_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/refined_glowstone_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/double_ingot/refined_glowstone"
+    "item": "tfc_metallum:metal/double_sheet/refined_glowstone"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/refined_glowstone"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/refined_glowstone_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/refined_glowstone_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/ingot/refined_glowstone"
+    "item": "tfc_metallum:metal/sheet/refined_glowstone"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/refined_glowstone"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/refined_obsidian_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/refined_obsidian_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/double_ingot/refined_obsidian"
+    "item": "tfc_metallum:metal/double_sheet/refined_obsidian"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/refined_obsidian"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/refined_obsidian_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/refined_obsidian_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/ingot/refined_obsidian"
+    "item": "tfc_metallum:metal/sheet/refined_obsidian"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/refined_obsidian"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/rose_gold_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/rose_gold_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc:metal/double_ingot/rose_gold"
+    "item": "tfc:metal/double_sheet/rose_gold"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/rose_gold"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/rose_gold_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/rose_gold_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc:metal/ingot/rose_gold"
+    "item": "tfc:metal/sheet/rose_gold"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/rose_gold"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/signalum_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/signalum_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/double_ingot/signalum"
+    "item": "tfc_metallum:metal/double_sheet/signalum"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/signalum"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/signalum_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/signalum_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/ingot/signalum"
+    "item": "tfc_metallum:metal/sheet/signalum"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/signalum"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/silver_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/silver_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc:metal/double_ingot/silver"
+    "item": "tfc:metal/double_sheet/silver"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/silver"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/silver_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/silver_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc:metal/ingot/silver"
+    "item": "tfc:metal/sheet/silver"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/silver"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/solder_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/solder_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/double_ingot/solder"
+    "item": "tfc_metallum:metal/double_sheet/solder"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/solder"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/solder_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/solder_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/ingot/solder"
+    "item": "tfc_metallum:metal/sheet/solder"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/solder"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/stainless_steel_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/stainless_steel_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "firmalife:metal/double_ingot/stainless_steel"
+    "item": "firmalife:metal/double_sheet/stainless_steel"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/stainless_steel"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/stainless_steel_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/stainless_steel_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "firmalife:metal/ingot/stainless_steel"
+    "item": "firmalife:metal/sheet/stainless_steel"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/stainless_steel"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/steel_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/steel_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc:metal/double_ingot/steel"
+    "item": "tfc:metal/double_sheet/steel"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/steel"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/steel_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/steel_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc:metal/ingot/steel"
+    "item": "tfc:metal/sheet/steel"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/steel"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/sterling_silver_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/sterling_silver_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc:metal/double_ingot/sterling_silver"
+    "item": "tfc:metal/double_sheet/sterling_silver"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/sterling_silver"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/sterling_silver_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/sterling_silver_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc:metal/ingot/sterling_silver"
+    "item": "tfc:metal/sheet/sterling_silver"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/sterling_silver"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/thorium_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/thorium_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/double_ingot/thorium"
+    "item": "tfc_metallum:metal/double_sheet/thorium"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/thorium"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/thorium_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/thorium_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/ingot/thorium"
+    "item": "tfc_metallum:metal/sheet/thorium"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/thorium"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/tin_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/tin_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc:metal/double_ingot/tin"
+    "item": "tfc:metal/double_sheet/tin"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/tin"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/tin_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/tin_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc:metal/ingot/tin"
+    "item": "tfc:metal/sheet/tin"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/tin"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/titanium_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/titanium_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/double_ingot/titanium"
+    "item": "tfc_metallum:metal/double_sheet/titanium"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/titanium"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/titanium_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/titanium_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/ingot/titanium"
+    "item": "tfc_metallum:metal/sheet/titanium"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/titanium"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/tungsten_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/tungsten_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/double_ingot/tungsten"
+    "item": "tfc_metallum:metal/double_sheet/tungsten"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/tungsten"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/tungsten_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/tungsten_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/ingot/tungsten"
+    "item": "tfc_metallum:metal/sheet/tungsten"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/tungsten"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/tungsten_steel_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/tungsten_steel_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/double_ingot/tungsten_steel"
+    "item": "tfc_metallum:metal/double_sheet/tungsten_steel"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/tungsten_steel"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/tungsten_steel_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/tungsten_steel_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/ingot/tungsten_steel"
+    "item": "tfc_metallum:metal/sheet/tungsten_steel"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/tungsten_steel"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/uranium_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/uranium_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/double_ingot/uranium"
+    "item": "tfc_metallum:metal/double_sheet/uranium"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/uranium"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/uranium_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/uranium_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc_metallum:metal/ingot/uranium"
+    "item": "tfc_metallum:metal/sheet/uranium"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/uranium"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/wrought_iron_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/wrought_iron_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc:metal/double_ingot/wrought_iron"
+    "item": "tfc:metal/double_sheet/wrought_iron"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/wrought_iron"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/wrought_iron_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/wrought_iron_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc:metal/ingot/wrought_iron"
+    "item": "tfc:metal/sheet/wrought_iron"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/wrought_iron"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/zinc_large_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/zinc_large_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc:metal/double_ingot/zinc"
+    "item": "tfc:metal/double_sheet/zinc"
   },
   "result": {
     "item": "tfc_metalwork:metal/large_plate/zinc"

--- a/src/main/resources/data/tfc_metalwork/recipes/anvil/zinc_plate.json
+++ b/src/main/resources/data/tfc_metalwork/recipes/anvil/zinc_plate.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:anvil",
   "input": {
-    "item": "tfc:metal/ingot/zinc"
+    "item": "tfc:metal/sheet/zinc"
   },
   "result": {
     "item": "tfc_metalwork:metal/plate/zinc"


### PR DESCRIPTION
fixed a metal duplication exploit when creating plates in anvil by replacing ingots with sheets